### PR TITLE
Fix macOS build, drop cmake and c++ minimum requirements slightly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,14 @@
-cmake_minimum_required(VERSION 3.21.1)
+cmake_minimum_required(VERSION 3.16)
 
 project(libsa)
-
-set(CMAKE_CXX_STANDARD 20)
 
 enable_testing()
 
 add_library(libsa sa.cpp)
 
 set_target_properties(libsa PROPERTIES PUBLIC_HEADER sa.h)
+
+target_compile_features(libsa PRIVATE cxx_std_17)
 
 install(TARGETS libsa DESTINATION lib PUBLIC_HEADER DESTINATION include)
 

--- a/common.h
+++ b/common.h
@@ -1,3 +1,5 @@
+#include <stdlib.h>
+
 #if _WIN32
 
 #include <ws2tcpip.h>
@@ -5,7 +7,10 @@
 
 #else
 
+#include <arpa/inet.h>
 #include <sys/socket.h>
+#include <sys/types.h>
+#include <netinet/in.h>
 #include <net/if.h>
 
 #endif

--- a/sa.h
+++ b/sa.h
@@ -8,7 +8,9 @@
 #define SOCKADDR_NET_EXPORT extern
 #endif
 
+#ifdef __cplusplus
 extern "C" {
+#ifdef __cplusplus
 
 SOCKADDR_NET_EXPORT bool sa_is_ipv4(struct sockaddr *sa);
 
@@ -32,4 +34,6 @@ SOCKADDR_NET_EXPORT const char * sa_get_scope(struct sockaddr *sa);
 
 SOCKADDR_NET_EXPORT bool sa_set_scope(struct sockaddr *sa, const char * scope);
 
+#ifdef __cplusplus
 }
+#ifdef __cplusplus

--- a/sa.h
+++ b/sa.h
@@ -10,7 +10,7 @@
 
 #ifdef __cplusplus
 extern "C" {
-#ifdef __cplusplus
+#endif
 
 SOCKADDR_NET_EXPORT bool sa_is_ipv4(struct sockaddr *sa);
 
@@ -36,4 +36,4 @@ SOCKADDR_NET_EXPORT bool sa_set_scope(struct sockaddr *sa, const char * scope);
 
 #ifdef __cplusplus
 }
-#ifdef __cplusplus
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(CMAKE_CXX_STANDARD 17)
+
 include(FetchContent)
 
 FetchContent_Declare(googletest URL https://github.com/google/googletest/archive/master.zip)
@@ -5,7 +7,6 @@ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
 include(GoogleTest)
-
 
 function(define_gtest test_name)
     add_executable(${test_name} ${test_name}.cpp)
@@ -25,4 +26,3 @@ define_gtest(test_sa_get_port)
 define_gtest(test_sa_set_port)
 define_gtest(test_sa_get_scope)
 define_gtest(test_sa_set_scope)
-


### PR DESCRIPTION
macOS doesn't have all the socket functions included in all the high level headers. Include all the headers explicitly needed for the functions used.

Additionally, lower the minimum cmake to 3.16 (We've found over the years this is a good balance, as many platforms have at least that, and you get a large majority of the features). Also lowers C++ to 17 (By using the proper cmake flags to handle this). Lots of platforms don't have access to 20 yet, and at least in the main library its unlikely C++20 features would actually be useful (I actually want to open an issue about making it C to avoid libstdc++ compatiblity issues, but thats a different discussion). 

And finally, add ifdefs around extern "C" so the header can be used from C.