### PR TITLE
Add get and set family funcs, along with a flag to check for len field

### DIFF
--- a/common.h
+++ b/common.h
@@ -1,3 +1,5 @@
+#include <stddef.h>
+
 #if _WIN32
 
 #include <ws2tcpip.h>

--- a/sa.cpp
+++ b/sa.cpp
@@ -173,4 +173,16 @@ bool sa_set_scope(sockaddr *sa, const char *scope) {
     return false;
 }
 
+bool sa_has_len_field(void) {
+    return offsetof(struct sockaddr, sa_family) != 0;
+}
+
+void sa_set_family(struct sockaddr *sa, sa_family_t family) {
+    sa->sa_family = family;
+}
+
+sa_family_t sa_get_family(const struct sockaddr *sa) {
+    return sa->sa_family;
+}
+
 }

--- a/sa.h
+++ b/sa.h
@@ -32,4 +32,10 @@ SOCKADDR_NET_EXPORT const char * sa_get_scope(struct sockaddr *sa);
 
 SOCKADDR_NET_EXPORT bool sa_set_scope(struct sockaddr *sa, const char * scope);
 
+SOCKADDR_NET_EXPORT bool sa_has_len_field(void);
+
+SOCKADDR_NET_EXPORT void sa_set_family(struct sockaddr *sa, sa_family_t family);
+
+SOCKADDR_NET_EXPORT sa_family_t sa_get_family(const struct sockaddr *sa);
+
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,4 +25,6 @@ define_gtest(test_sa_get_port)
 define_gtest(test_sa_set_port)
 define_gtest(test_sa_get_scope)
 define_gtest(test_sa_set_scope)
-
+define_gtest(test_sa_get_family)
+define_gtest(test_sa_set_family)
+define_gtest(test_sa_has_len_field)

--- a/tests/test_sa_get_family.cpp
+++ b/tests/test_sa_get_family.cpp
@@ -1,0 +1,31 @@
+#include <gtest/gtest.h>
+#include "../common.h"
+#include "../sa.h"
+
+TEST(libsatest, test_sa_get_family_unspec) {
+    sockaddr_in sa{.sin_family = AF_UNSPEC, .sin_port = htons(1000)};
+
+    auto actual = sa_get_family(reinterpret_cast<sockaddr *>(&sa));
+
+    EXPECT_EQ(actual, AF_UNSPEC);
+}
+
+TEST(libsatest, test_sa_get_family_ipv4) {
+    sockaddr_in sa{.sin_family = AF_INET, .sin_port = htons(1000)};
+
+    EXPECT_EQ(inet_pton(AF_INET, "1.2.3.4", &sa.sin_addr), 1);
+
+    auto actual = sa_get_family(reinterpret_cast<sockaddr *>(&sa));
+
+    EXPECT_EQ(actual, AF_INET);
+}
+
+TEST(libsatest, test_sa_get_family_ipv6) {
+    sockaddr_in6 sa{.sin6_family = AF_INET6, .sin6_port = htons(1000)};
+
+    EXPECT_EQ(inet_pton(AF_INET6, "::ffff:0102:0304", &sa.sin6_addr), 1);
+
+    auto actual = sa_get_family(reinterpret_cast<sockaddr *>(&sa));
+
+    EXPECT_EQ(actual, AF_INET6);
+}

--- a/tests/test_sa_has_len_field.cpp
+++ b/tests/test_sa_has_len_field.cpp
@@ -1,0 +1,11 @@
+#include <gtest/gtest.h>
+#include "../common.h"
+#include "../sa.h"
+
+TEST(libsatest, test_sa_has_len_field) {
+#ifdef SIN6_LEN
+    EXPECT_EQ(sa_has_len_field(), true);
+#else
+    EXPECT_EQ(sa_has_len_field(), false);
+#endif
+}

--- a/tests/test_sa_set_family.cpp
+++ b/tests/test_sa_set_family.cpp
@@ -1,0 +1,27 @@
+#include <gtest/gtest.h>
+#include "../common.h"
+#include "../sa.h"
+
+TEST(libsatest, test_sa_set_family_unspec) {
+    sockaddr_in sa{.sin_family = AF_INET, .sin_port = htons(1000)};
+
+    sa_set_family(reinterpret_cast<sockaddr *>(&sa), AF_UNSPEC);
+
+    EXPECT_EQ(sa.sin_family, AF_UNSPEC);
+}
+
+TEST(libsatest, test_sa_set_family_ipv4) {
+    sockaddr_in sa{.sin_family = AF_UNSPEC, .sin_port = htons(1000)};
+
+    sa_set_family(reinterpret_cast<sockaddr *>(&sa), AF_INET);
+
+    EXPECT_EQ(sa.sin_family, AF_INET);
+}
+
+TEST(libsatest, test_sa_set_family_ipv6) {
+    sockaddr_in6 sa{.sin6_family = AF_UNSPEC, .sin6_port = htons(1000)};
+
+    sa_set_family(reinterpret_cast<sockaddr *>(&sa), AF_INET6);
+
+    EXPECT_EQ(sa.sin6_family, AF_INET6);
+}


### PR DESCRIPTION
There should be functions to explicitly get and set a family, This is useful for AF_UNSPEC, or things like AF_CAN. 

Also, the big platform difference is if a len field exists. Add a way to detect this case, so of the struct could be done in a managed language if a user wanted to do so.